### PR TITLE
s03: Step 3: Implement RAG chat with indexed PDFs 

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -3,10 +3,21 @@
 import { useState, useRef, useEffect } from 'react';
 import { api } from '@/services/api';
 
+interface PDFFile {
+  file_id: string;
+  original_filename: string;
+  uploaded_at: number;
+  indexing_status: string;
+  indexing_message: string;
+}
+
 export default function Chat() {
   const [messages, setMessages] = useState<string[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [pdfs, setPdfs] = useState<PDFFile[]>([]);
+  const [selectedPDF, setSelectedPDF] = useState<string>('');
+  const [chatMode, setChatMode] = useState<'general' | 'pdf'>('general');
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottom = () => {
@@ -16,6 +27,20 @@ export default function Chat() {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  // Load PDFs on component mount
+  useEffect(() => {
+    loadPDFs();
+  }, []);
+
+  const loadPDFs = async () => {
+    try {
+      const response = await api.listPDFs();
+      setPdfs(response.pdfs);
+    } catch (error) {
+      console.error('Failed to load PDFs:', error);
+    }
+  };
 
   const developerMessage = `
     You are a helpful AI assistant.
@@ -51,10 +76,21 @@ export default function Chat() {
     setMessages(prev => [...prev, `You: ${userMessage}`]);
 
     try {
-      const stream = await api.chat({
-        developer_message: developerMessage,
-        user_message: userMessage,
-      });
+      let stream: ReadableStream;
+
+      if (chatMode === 'pdf' && selectedPDF) {
+        // Chat with PDF using RAG
+        stream = await api.chatWithPDF({
+          user_message: userMessage,
+          pdf_file_id: selectedPDF,
+        });
+      } else {
+        // General chat
+        stream = await api.chat({
+          developer_message: developerMessage,
+          user_message: userMessage,
+        });
+      }
 
       const reader = stream.getReader();
       let response = '';
@@ -77,15 +113,101 @@ export default function Chat() {
       }
     } catch (error) {
       console.error('Error:', error);
-      setMessages(prev => [...prev, 'Error: Failed to get response']);
+      setMessages(prev => [...prev, `Error: Failed to get response`]);
     } finally {
       setIsLoading(false);
     }
   };
 
+  const handlePDFSelection = (fileId: string) => {
+    setSelectedPDF(fileId);
+    setChatMode('pdf');
+    setMessages([]); // Clear chat history when switching PDFs
+  };
+
+  const handleGeneralChat = () => {
+    setChatMode('general');
+    setSelectedPDF('');
+    setMessages([]); // Clear chat history when switching modes
+  };
+
+  const getSelectedPDFName = () => {
+    if (!selectedPDF) return '';
+    const pdf = pdfs.find(p => p.file_id === selectedPDF);
+    return pdf ? pdf.original_filename : '';
+  };
+
+  const readyPDFs = pdfs.filter(pdf => pdf.indexing_status === 'completed');
+
   return (
     <div className="flex flex-col h-[80vh] max-w-2xl mx-auto p-4">
+      {/* Chat Mode Selection */}
+      <div className="mb-4 flex gap-2">
+        <button
+          onClick={handleGeneralChat}
+          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+            chatMode === 'general'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+          }`}
+        >
+          General Chat
+        </button>
+        <button
+          onClick={() => setChatMode('pdf')}
+          className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+            chatMode === 'pdf'
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+          }`}
+        >
+          Chat with PDF
+        </button>
+      </div>
+
+      {/* PDF Selection (only show when in PDF mode) */}
+      {chatMode === 'pdf' && (
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Select a PDF to chat with:
+          </label>
+          {readyPDFs.length === 0 ? (
+            <div className="text-sm text-gray-500 bg-gray-50 p-3 rounded-lg">
+              No indexed PDFs available. Please upload and wait for indexing to complete.
+            </div>
+          ) : (
+            <select
+              value={selectedPDF}
+              onChange={(e) => handlePDFSelection(e.target.value)}
+              className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              <option value="">Choose a PDF...</option>
+              {readyPDFs.map((pdf) => (
+                <option key={pdf.file_id} value={pdf.file_id}>
+                  {pdf.original_filename}
+                </option>
+              ))}
+            </select>
+          )}
+          {selectedPDF && (
+            <div className="mt-2 text-sm text-blue-600">
+              Chatting with: <strong>{getSelectedPDFName()}</strong>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Messages */}
       <div className="flex-1 overflow-y-auto mb-1 space-y-4">
+        {messages.length === 0 && (
+          <div className="text-center text-gray-500 py-8">
+            {chatMode === 'pdf' && !selectedPDF ? (
+              <p>Select a PDF above to start chatting with it!</p>
+            ) : (
+              <p>Start a conversation by typing a message below.</p>
+            )}
+          </div>
+        )}
         {messages.map((message, index) => (
           <div
             key={index}
@@ -101,18 +223,23 @@ export default function Chat() {
         <div ref={messagesEndRef} />
       </div>
 
+      {/* Input Form */}
       <form onSubmit={handleSubmit} className="flex gap-2">
         <input
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="Type your message..."
+          placeholder={
+            chatMode === 'pdf' && !selectedPDF
+              ? "Select a PDF first..."
+              : "Type your message..."
+          }
           className="flex-1 p-2 border rounded"
-          disabled={isLoading}
+          disabled={isLoading || (chatMode === 'pdf' && !selectedPDF)}
         />
         <button
           type="submit"
-          disabled={isLoading || !input.trim()}
+          disabled={isLoading || !input.trim() || (chatMode === 'pdf' && !selectedPDF)}
           className="px-4 py-2 bg-blue-500 text-white rounded disabled:bg-gray-300"
         >
           {isLoading ? 'Sending...' : 'Send'}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,6 +4,12 @@ interface ChatRequest {
   model?: string;
 }
 
+interface PDFChatRequest {
+  user_message: string;
+  pdf_file_id: string;
+  model?: string;
+}
+
 interface PDFUploadResponse {
   filename: string;
   file_id: string;
@@ -49,6 +55,23 @@ export const api = {
 
     if (!response.ok) {
       throw new Error('Failed to get chat response');
+    }
+
+    return response.body as ReadableStream;
+  },
+
+  async chatWithPDF(request: PDFChatRequest): Promise<ReadableStream> {
+    const response = await fetch(`${API_BASE_URL}/api/chat-pdf`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to chat with PDF: ${errorText}`);
     }
 
     return response.body as ReadableStream;


### PR DESCRIPTION
- Backend: Add /api/chat-pdf endpoint with vector search and context injection - Frontend: Add PDF selection and chat mode switching in Chat component - Implement RAG-based responses using relevant PDF chunks - Add in-memory vector database storage for quick access - Users can now chat with their uploaded and indexed PDFs

![image](https://github.com/user-attachments/assets/54919173-1c9b-4519-8038-ca759a052e16)
